### PR TITLE
[NOISSUE] Remove hardcoded admin account with support for multiple admins

### DIFF
--- a/app/auxil.php
+++ b/app/auxil.php
@@ -63,8 +63,22 @@ class Helper
     // to always be passed in.
     public static function is_admin($email)
     {
-        if ($email == "admin@sfjamaat.org") {
-            return true;
+        global $db; // Refers to the global variable declared in oo_db.php
+        $sql = "SELECT resp FROM `family` WHERE `email` = '$email' LIMIT 1;";
+        $result = $db->query($sql) or die("{ msg: 'Can't determine if user is Admin' }");
+        if (!$result || $result->num_rows != 1) {
+            return false;
+        }
+        $row = $result->fetch_assoc();
+
+        if(!$row['resp']) {
+            return false;
+        }
+        $responsibilities = explode(',', $row['resp']);
+        foreach($responsibilities as $resp) {
+            if ($resp == 'A') { // A for Admin
+                return true;
+            }
         }
         return false;
     }

--- a/app/oo_db.php
+++ b/app/oo_db.php
@@ -20,7 +20,6 @@ class DB {
         // convention is to use $db or $mysqli for the db handle
         $this->mysqli = new mysqli($this->dbhost, $this->dbusername,
                                    $this->dbpassword, $this->dbname);
-
         if ($this->mysqli->connect_errno) {
             $this->log_error($this->mysqli->connect_error);
             throw new Exception($this->mysqli->connect_error);

--- a/deploy.pl
+++ b/deploy.pl
@@ -5,8 +5,9 @@ use File::Find;
 use Cwd;
 
 # Global variables
-my $webpass = (shift or '');
-my $mysqlpass = (shift or '');
+my $dbhost = (shift or '');
+my $dbusername = (shift or '');
+my $dbpassword = (shift or '');
 my $dbname = (shift or '');
 
 find (\&wanted, 'build');
@@ -16,9 +17,6 @@ sub wanted {
 
     if (m/oo_db.php/) {
         oo($_);
-        return;
-    } elsif (m/aux/) {
-        aux($_);
         return;
     } elsif (m/index\.html/) {
         html($_);
@@ -33,28 +31,13 @@ sub oo {
     open OUT, ">$_.backup" or die "Cannot open $!";
     while ($line = <IN>) {
         if ($line =~ m/dbhost =/) {
-            $line =~ s/127.0.0.1/mysql-1.sfjamaat.org/;
+            $line =~ s/127.0.0.1/$dbhost/;
+        } elsif ($line =~ m/dbusername =/) {
+            $line =~ s/sffaiz/$dbusername/;
         } elsif ($line =~ m/dbpassword =/) {
-            $line =~ s/sffaiz-pass/$mysqlpass/;
+            $line =~ s/sffaiz-pass/$dbpassword/;
         } elsif ($line =~ m/dbname =/ and $dbname) {
             $line =~ s/sffaiz/$dbname/;
-        }
-        print OUT $line;
-    }
-    close OUT;
-    close IN;
-    rename "$_.backup", $_;
-}
-
-sub aux {
-    return unless $webpass;
-    my $line;
-    $_ = shift;
-    open IN, $_ or die "Cannot open $!";
-    open OUT, ">$_.backup" or die "Cannot open $!";
-    while ($line = <IN>) {
-        if ($line =~ m/admin\@sfjamaat.org/) {
-            $line =~ s/admin\@sfjamaat.org/$webpass/;
         }
         print OUT $line;
     }

--- a/migration/01_setup.sql
+++ b/migration/01_setup.sql
@@ -21,7 +21,8 @@ CREATE TABLE family
     size char,
     email varchar(255) NOT NULL,
     phone varchar(255),
-    area varchar(255)
+    area varchar(255),
+    isAdmin tinyint(1) DEFAULT 0,
   );
 
 CREATE TABLE events
@@ -42,26 +43,23 @@ CREATE TABLE rsvps
 -- Dummy data
 --
 
+-- Create an Admin account
+insert into family
+  ( thaali, lastName, firstName, email, phone , area, isAdmin )
+  values
+  ( 0, 'Admin', 'Admin', 'Admin@Admin', '000-000-0000', 'Area1', 1 );
+
+-- Create dummy families
+-- These can be replaced with real families
+--
 insert into family
   ( thaali, lastName, firstName, email, phone, area )
   values
-  ( 36, 'Yamani', 'Ali Akber', 'lakhia@gmail.com', '510-565-7861' , 'Masjid');
+  ( 1, 'Anonymous', 'Mumin bhai', 'randomemail@gmail.com', '000-000-0000' , 'Area1');
 insert into family
   ( thaali, lastName, firstName, email, phone, area  )
   values
-  ( 5, 'Pedhiwala', 'Mohammed', 'mpedhiwala@gmail.com', '510-494-1520', 'Masjid' );
-insert into family
-  ( thaali, lastName, firstName, email, phone, area  )
-  values
-  ( 6, 'Bootwala', 'Mustafa', 'mabootwala@gmail.com', '650-676-8849', 'Ardenwood' );
-insert into family
-  ( thaali, lastName, firstName, email, phone , area )
-  values
-  ( 7, 'Patanwala', 'Aliasgar', 'apatanwala@gmail.com', '650-276-8037','Sacramento' );
-insert into family
-  ( thaali, lastName, firstName, email, phone , area )
-  values
-  ( 8, 'Partapurwala', 'Murtaza', 'murtazap@gmail.com', '510-579-4909', 'Sacramento' );
+  ( 2, 'Anonymous', 'Mumina behen', 'randomemail@gmail.com', '000-000-0000', 'Area1' );
 
 insert into events
   ( date, details)


### PR DESCRIPTION
[NOISSUE] Remove hardcoded admin account with support for multiple admins

[Problem]

Admin account was hard-coded for a single user. This if condition will not scale when deploying this for multiple jamaats

[Solution]

Add a new field `isAdmin` to the family table schema. Logging in with an email that with isAdmin = 1 gives admin privileges.

Create an admin-only account with thaali #0

Replace families with anonymous variants for privacy reasons. (These will still be visible if someone digs deep into the git history)

[Testing]

gulp serve on localhost

![admin-admin-with-all-tabs-available](https://github.com/lakhia/rsvp-website/assets/1933223/78fd846f-b963-4cbe-ba89-b35077e5a981)

[Issue]

NOISSUE