### PR TITLE
[NOISSUE] Modify deploy script to remove hard-coded strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ On the backend, it currently requires:
   * When ready to deploy, run "gulp" and publish all files in build directory
     except for hidden .tmp sub-directory
   * Run deployment squasher:
-     cd rsvp; perl deploy.pl <site_admin_email> <qa>
-    Note that "qa" will default to empty string for production. 
+    `cd rsvp; perl deploy.pl <dbhost> <dbusername> <dbpassword> <dbname> <adminemail> 
 
 # Files
 
@@ -58,3 +57,11 @@ On the backend, it currently requires:
   * Uses angular-ui-router to route to different parts of the app
   * Uses bootstrap to style buttons, tables, etc.
   * Uses loading-bar to show progress bar at top
+
+# Note about admin email
+
+Using the `adminemail` for login with ANY thaali number allows you to assume the role of any thaali number. You can make changes on their behalf without being subjected to the limitations of the regular user.
+
+Keep the `adminemail` safe.
+
+_We want to move away from this approach in the long-term, PRs are welcome_

--- a/app/oo_db.php
+++ b/app/oo_db.php
@@ -20,7 +20,6 @@ class DB {
         // convention is to use $db or $mysqli for the db handle
         $this->mysqli = new mysqli($this->dbhost, $this->dbusername,
                                    $this->dbpassword, $this->dbname);
-
         if ($this->mysqli->connect_errno) {
             $this->log_error($this->mysqli->connect_error);
             throw new Exception($this->mysqli->connect_error);

--- a/deploy.pl
+++ b/deploy.pl
@@ -5,9 +5,11 @@ use File::Find;
 use Cwd;
 
 # Global variables
-my $webpass = (shift or '');
-my $mysqlpass = (shift or '');
+my $dbhost = (shift or '');
+my $dbusername = (shift or '');
+my $dbpassword = (shift or '');
 my $dbname = (shift or '');
+my $adminemail = (shift or '');
 
 find (\&wanted, 'build');
 
@@ -20,7 +22,8 @@ sub wanted {
     } elsif (m/aux/) {
         aux($_);
         return;
-    } elsif (m/index\.html/) {
+    }
+    elsif (m/index\.html/) {
         html($_);
         return;
     }
@@ -33,9 +36,11 @@ sub oo {
     open OUT, ">$_.backup" or die "Cannot open $!";
     while ($line = <IN>) {
         if ($line =~ m/dbhost =/) {
-            $line =~ s/127.0.0.1/mysql-1.sfjamaat.org/;
+            $line =~ s/127.0.0.1/$dbhost/;
+        } elsif ($line =~ m/dbusername =/) {
+            $line =~ s/sffaiz/$dbusername/;
         } elsif ($line =~ m/dbpassword =/) {
-            $line =~ s/sffaiz-pass/$mysqlpass/;
+            $line =~ s/sffaiz-pass/$dbpassword/;
         } elsif ($line =~ m/dbname =/ and $dbname) {
             $line =~ s/sffaiz/$dbname/;
         }
@@ -47,14 +52,14 @@ sub oo {
 }
 
 sub aux {
-    return unless $webpass;
+    return unless $adminemail;
     my $line;
     $_ = shift;
     open IN, $_ or die "Cannot open $!";
     open OUT, ">$_.backup" or die "Cannot open $!";
     while ($line = <IN>) {
         if ($line =~ m/admin\@sfjamaat.org/) {
-            $line =~ s/admin\@sfjamaat.org/$webpass/;
+            $line =~ s/admin\@sfjamaat.org/$adminemail/;
         }
         print OUT $line;
     }

--- a/migration/01_setup.sql
+++ b/migration/01_setup.sql
@@ -40,28 +40,17 @@ CREATE TABLE rsvps
 
 --
 -- Dummy data
+-- Create dummy families
+-- These can be replaced with real families
 --
-
 insert into family
   ( thaali, lastName, firstName, email, phone, area )
   values
-  ( 36, 'Yamani', 'Ali Akber', 'lakhia@gmail.com', '510-565-7861' , 'Masjid');
+  ( 1, 'Anonymous', 'Mumin bhai', 'randomemail@gmail.com', '000-000-0000' , 'Area1');
 insert into family
   ( thaali, lastName, firstName, email, phone, area  )
   values
-  ( 5, 'Pedhiwala', 'Mohammed', 'mpedhiwala@gmail.com', '510-494-1520', 'Masjid' );
-insert into family
-  ( thaali, lastName, firstName, email, phone, area  )
-  values
-  ( 6, 'Bootwala', 'Mustafa', 'mabootwala@gmail.com', '650-676-8849', 'Ardenwood' );
-insert into family
-  ( thaali, lastName, firstName, email, phone , area )
-  values
-  ( 7, 'Patanwala', 'Aliasgar', 'apatanwala@gmail.com', '650-276-8037','Sacramento' );
-insert into family
-  ( thaali, lastName, firstName, email, phone , area )
-  values
-  ( 8, 'Partapurwala', 'Murtaza', 'murtazap@gmail.com', '510-579-4909', 'Sacramento' );
+  ( 2, 'Anonymous', 'Mumina behen', 'randomemail@gmail.com', '000-000-0000', 'Area1' );
 
 insert into events
   ( date, details)


### PR DESCRIPTION
[Problem]

deploy script had hard-coded constants that would not work for other jamaats.

[Solution]

Replace families with anonymous variants for privacy reasons. (These will still be visible if someone digs deep into the git history)

Modified the deploy.pl file to be used by other jamaats and their mysql configurations.

Added a note about the use of the `adminemail`

[Testing]

gulp serve on localhost. See Screenshot in PR comments.

Tested the deploy.pl changes by  deploying and testing on http://fmbvancouver.dreamhosters.com/

[Issue]

NOISSUE