### PR TITLE
Display size options as XL/LG/MD/SM/XS instead of XL/L/M/S/XS

### DIFF
--- a/app/js/print.js
+++ b/app/js/print.js
@@ -1,6 +1,6 @@
 /* Printout controller */
-app.controller("printController", ["$scope", '$rootScope',
-function($scope, $rootScope) {
+app.controller("printController", ["$scope", '$rootScope', 'sizeService',
+function($scope, $rootScope, sizeService) {
 
     $scope.init = function() {
         $rootScope.init($scope, "print.php", handleResponse);
@@ -10,6 +10,11 @@ function($scope, $rootScope) {
 
     function handleResponse(response) {
         $scope.raw = response.data;
+        if ($scope.raw) {
+            $scope.raw.forEach(function(item) {
+                item.displaySize = sizeService.sizeToDisplay(item.size);
+            });
+        }
         $scope.data = [];
     }
 
@@ -103,9 +108,9 @@ function($scope, $rootScope) {
                 return prev;
             }, {});
             return "XS: " + (sizes['XS'] || 0)
-               + ", S: " + (sizes['S'] || 0)
-               + ", M: " + (sizes['M'] || 0)
-               + ", L: " + (sizes['L'] || 0)
+               + ", SM: " + (sizes['S'] || 0)
+               + ", MD: " + (sizes['M'] || 0)
+               + ", LG: " + (sizes['L'] || 0)
                + ", XL: " + (sizes['XL'] || 0);
         }
     }

--- a/app/js/rsvp.js
+++ b/app/js/rsvp.js
@@ -1,6 +1,6 @@
 /* RSVP controller */
-app.controller("rsvpController", ["$scope", "$rootScope",
-function($scope, $rootScope) {
+app.controller("rsvpController", ["$scope", "$rootScope", "sizeService",
+function($scope, $rootScope, sizeService) {
     $scope.o = [];
 
     $scope.init = function() {
@@ -14,6 +14,19 @@ function($scope, $rootScope) {
 
     function handleResponse(response) {
         $scope.raw = response.data;
+        if ($scope.raw) {
+            Object.values($scope.raw).forEach(function(item) {
+                if (item.size) {
+                    item.displaySize = sizeService.sizeToDisplay(item.size);
+                }
+            });
+            // Convert available sizes to display format
+            if ($scope.o && $scope.o.length) {
+                $scope.displaySizes = $scope.o.map(function(size) {
+                    return sizeService.sizeToDisplay(size);
+                });
+            }
+        }
         $scope.data = {};
     }
 
@@ -58,11 +71,17 @@ function($scope, $rootScope) {
     }
 
     $scope.getSizes = function(currentSize) {
-        if ($scope.o.includes(currentSize)) {
-            return $scope.o;
+        var currentDisplaySize = sizeService.sizeToDisplay(currentSize);
+        if (!$scope.displaySizes) {
+            $scope.displaySizes = $scope.o.map(function(size) {
+                return sizeService.sizeToDisplay(size);
+            });
+        }
+        if ($scope.displaySizes.includes(currentDisplaySize)) {
+            return $scope.displaySizes;
         } else {
-            dupSizes = [...$scope.o];
-            dupSizes.push(currentSize);
+            var dupSizes = [...$scope.displaySizes];
+            dupSizes.push(currentDisplaySize);
             return dupSizes;
         }
     }
@@ -70,6 +89,8 @@ function($scope, $rootScope) {
     $scope.onSizeChange = function(id) {
         var dateData = onPreChange(id);
         var raw = $scope.raw[id];
+        // Convert display size back to database size
+        raw.size = sizeService.displayToSize(raw.displaySize);
         dateData.size = raw.size;
         onPostChange(id);
     }

--- a/app/js/services.js
+++ b/app/js/services.js
@@ -1,0 +1,26 @@
+/* Common services */
+app.service('sizeService', function() {
+    // Map database size values to display values
+    this.sizeToDisplay = function(size) {
+        const sizeMap = {
+            'XL': 'XL',
+            'L': 'LG',
+            'M': 'MD',
+            'S': 'SM',
+            'XS': 'XS'
+        };
+        return sizeMap[size] || size;
+    };
+
+    // Map display values back to database values
+    this.displayToSize = function(display) {
+        const displayMap = {
+            'XL': 'XL',
+            'LG': 'L',
+            'MD': 'M',
+            'SM': 'S',
+            'XS': 'XS'
+        };
+        return displayMap[display] || display;
+    };
+});

--- a/app/print.html
+++ b/app/print.html
@@ -44,7 +44,7 @@
     <tr ng-repeat="item in raw | orderBy: sorterFunc | filter: filterFunc">
       <td>{{ item["thaali"] }}</td>
       <td>{{ item["area"] }}</td>
-      <td>{{ item["size"] }}</td>
+      <td>{{ item["displaySize"] }}</td>
       <td ng-hide="o.niyaz">{{ item["bread+rice"] }}</td>
       <td ng-hide="o.niyaz">
         <input type="checkbox" ng-model='item.here' ng-checked="item.here==1"  ng-change="onCheckboxClick(item)"/>

--- a/app/rsvp.html
+++ b/app/rsvp.html
@@ -31,7 +31,7 @@
         </button>
       </td>
       <td>
-        <select ng-hide="!value.enabled || value.niyaz" ng_model="value.size" ng-disabled="value.readonly || !value.rsvp"
+        <select ng-hide="!value.enabled || value.niyaz" ng_model="value.displaySize" ng-disabled="value.readonly || !value.rsvp"
            ng-change="onSizeChange(key)">
           <option ng-repeat="size in getSizes(value.size)" ng-value="size">{{size}}</option>
         </select>


### PR DESCRIPTION
## Current Behavior
Size options throughout the application are displayed as:
- XL
- L
- M
- S
- XS

## Desired Behavior
Update size display format to use more consistent two-letter abbreviations:
- XL (unchanged)
- LG (was L)
- MD (was M)
- SM (was S)
- XS (unchanged)

## Implementation Notes
- Database values remain unchanged (XL/L/M/S/XS) to maintain compatibility
- Frontend handles the display transformation
- Affects both RSVP form and print view
- No changes to size calculations or business logic

## Files Affected
- app/js/services.js (new)
- app/js/print.js
- app/js/rsvp.js
- app/print.html
- app/rsvp.html

## Testing Checklist
- [ ] Size selection in RSVP form shows new format
- [ ] Print view displays new format
- [ ] Size filtering works correctly
- [ ] Size summary totals show correct labels
- [ ] Existing RSVPs maintain their sizes
- [ ] Size-based calculations remain accurate

## Additional Context
This change improves UI consistency by using standardized two-letter size abbreviations while maintaining backward compatibility with existing data.

https://github.com/lakhia/rsvp-website/issues/23