### PR TITLE
Minor tweaks to UI to help visually keep thaali ID and the group name together

### DIFF
--- a/app/family.html
+++ b/app/family.html
@@ -7,10 +7,10 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th class="col-xs-0">Num</th>
+      <th class="col-xs-1">Num</th>
+      <th class="col-xs-1">Area</th>
       <th class="col-xs-2">Name</th>
       <th class="col-xs-0">Size</th>
-      <th class="col-xs-0">Area</th>
       <th class="col-xs-3">Email</th>
       <th class="col-xs-3">Phone / POC</th>
       <th class="col-xs-0">Resp</th>
@@ -24,6 +24,10 @@
                placeholder="ITS ID" ng-change="onChange()"/>
       </td>
       <td>
+        <input type="area" ng-model="family.area" class="trans"
+               placeholder="Area" ng-change="onChange()"/>
+      </td>
+      <td>
         <input type="text" ng-model="family.firstName" class="trans"
                placeholder="First name" ng-change="onChange()"/>
         <input type="text" ng-model="family.lastName" class="trans"
@@ -32,10 +36,6 @@
       <td>
         <input type="text" ng-model="family.size" class="minWidth trans"
                placeholder="M" ng-change="onChange()"/>
-      </td>
-      <td>
-        <input type="area" ng-model="family.area" class="trans"
-               placeholder="Area" ng-change="onChange()"/>
       </td>
       <td>
         <input type="email" ng-model="family.email" class="trans"

--- a/app/print.html
+++ b/app/print.html
@@ -33,8 +33,8 @@
     <tr>
       <th class="col-xs-1">Thaali</th>
       <th class="col-xs-1"><input ng-model='filterNames.area' type="text" class="trans" ng-change="onFilterChange()" placeholder="Area"></th>
-      <th class="col-xs-1"><input ng-model='filterNames.size' type="text" class="trans" ng-change="onFilterChange()" placeholder="Size"></th>
       <th class="col-xs-1" ng-hide="o.niyaz"><input ng-model='filterNames.rice' type="text" class="trans" ng-change="onFilterChange()" placeholder="Rice/ Bread"></th>
+      <th class="col-xs-1"><input ng-model='filterNames.size' type="text" class="trans" ng-change="onFilterChange()" placeholder="Size"></th>
       <th class="col-xs-1" ng-hide="o.niyaz"><input ng-model='filterNames.here' type="text" class="trans" ng-change="onFilterChange()" placeholder="Here"></th>
       <th class="col-xs-1" ng-hide="o.niyaz"><input ng-model='filterNames.filled' type="text" class="trans" ng-change="onFilterChange()" placeholder="Filled"></th>
       <th><input type="text" ng-model='filterNames.name' class="trans" ng-change="onFilterChange()" placeholder="Name"></th>
@@ -42,10 +42,10 @@
   </thead>
   <tbody id="rTab">
     <tr ng-repeat="item in raw | orderBy: sorterFunc | filter: filterFunc">
-      <td>{{ item["thaali"] }}</td>
+      <td class="text-right">{{ item["thaali"] }}</td>
       <td>{{ item["area"] }}</td>
-      <td>{{ item["size"] }}</td>
       <td ng-hide="o.niyaz">{{ item["bread+rice"] }}</td>
+      <td><span class="badge">{{ item["size"] }}</span></td>
       <td ng-hide="o.niyaz">
         <input type="checkbox" ng-model='item.here' ng-checked="item.here==1"  ng-change="onCheckboxClick(item)"/>
       </td>


### PR DESCRIPTION
* The print page now visually shows the thaali ID and group name close together. Also, size is in a different column and shown with a background.
* The family page shows thaali ID and group together. Given that these are input fields, the background didn't go well so I left it as is. 

<img width="1254" height="650" alt="image" src="https://github.com/user-attachments/assets/43f93aa1-a1d8-4a50-8490-844404c69c9e" />
<img width="454" height="100" alt="image" src="https://github.com/user-attachments/assets/15470f3f-844a-4eed-846f-95fca923e034" />
